### PR TITLE
Add Borsh serialization support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added support for the `uuid` crate's `bytemuck` feature.
+- Added support for [Borsh](https://borsh.io/) serialization via the `uuid` crate's `borsh` feature.
 
 ## 0.6.0 - 2023-06-24
 
@@ -41,7 +42,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Added `PartialEq<T>` for `Vec<u8>` and `&[u8; 16]`. 
+- Added `PartialEq<T>` for `Vec<u8>` and `&[u8; 16]`.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,14 @@ readme = "README.md"
 rust-version = "1.67.1"
 
 [features]
-default = ["random"]
+default = ["fast-rng"]
 arbitrary = ["uuid/arbitrary", "arbitrary/derive"]  # Add support for arbitrary types
 random = ["uuid/v4"]                                # Create random ShortGuid IDs
-fast-rng = ["uuid/fast-rng"]                        # Use a faster (but still sufficiently random) RNG
+fast-rng = ["random", "uuid/fast-rng"]             # Use a faster (but still sufficiently random) RNG
 serde = ["dep:serde", "uuid/serde"]                 # Serialization and deserialization support
 # zerocopy = ["dep:zerocopy", "uuid/zerocopy"]        # Zerocopy support
 bytemuck = ["dep:bytemuck", "uuid/bytemuck"]        # Bytemuck support
+borsh = ["dep:borsh", "dep:borsh-derive", "uuid/borsh"]  # Borsh support
 
 [[example]]
 name = "shortguid"
@@ -31,15 +32,17 @@ required-features = ["serde"]
 
 [dependencies]
 arbitrary = { version = "1.3.2", optional = true }
-base64 = "0.21.5"
-bytemuck = { version = "1.14.0", optional = true, features = ["derive"] }
-serde = { version = "1.0.193", optional = true }
-uuid = "1.6.1"
-zerocopy = { version = "0.7.32", optional = true, features = ["derive"] }
+base64 = "0.22.1"
+borsh = { version = "1.5.0", optional = true, features = ["derive"] }
+borsh-derive = { version = "1.5.0", optional = true }
+bytemuck = { version = "1.15.0", optional = true, features = ["derive"] }
+serde = { version = "1.0.200", optional = true }
+uuid = "1.8.0"
+zerocopy = { version = "0.7.33", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 hex = "0.4.3"
-clap = "4.4.11"
+clap = "4.5.4"
 serde_test = "1.0.176"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Adds support for the UUID crate's [Borsh](https://borsh.io/) serialization feature:

```rust
#[test]
fn test_serialize() {
    let uuid_str = "f9168c5e-ceb2-4faa-b6bf-329bf39fa1e4";
    let sg = ShortGuid::from_str(uuid_str).unwrap();
    let sg_bytes = sg.as_bytes().to_vec();
    let borsh_bytes = borsh::to_vec(&sg).unwrap();
    assert_eq!(sg_bytes, borsh_bytes);
}

#[test]
fn test_deserialize() {
    let uuid_str = "f9168c5e-ceb2-4faa-b6bf-329bf39fa1e4";
    let sg = ShortGuid::from_str(uuid_str).unwrap();
    let sg_bytes = sg.as_bytes().to_vec();
    let deserialized = borsh::from_slice::<Uuid>(&sg_bytes).unwrap().to_string();
    assert_eq!(uuid_str, deserialized);
}
```

This also defaults the (default-active) randomizer to the `fast-rng` feature.