### PR TITLE
Add zerocopy support for UUID crate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg=uuid_unstable"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ arbitrary = ["uuid/arbitrary", "arbitrary/derive"]  # Add support for arbitrary 
 random = ["uuid/v4"]                                # Create random ShortGuid IDs
 fast-rng = ["uuid/fast-rng"]                        # Use a faster (but still sufficiently random) RNG
 serde = ["dep:serde", "uuid/serde"]                 # Serialization and deserialization support
-# zerocopy = ["dep:zerocopy", "uuid/zerocopy"]        # Zerocopy support
+zerocopy = ["dep:zerocopy", "uuid/zerocopy"]        # Zerocopy support
 bytemuck = ["dep:bytemuck", "uuid/bytemuck"]        # Bytemuck support
 
 [[example]]
@@ -31,15 +31,15 @@ required-features = ["serde"]
 
 [dependencies]
 arbitrary = { version = "1.3.2", optional = true }
-base64 = "0.21.5"
-bytemuck = { version = "1.14.0", optional = true, features = ["derive"] }
-serde = { version = "1.0.193", optional = true }
-uuid = "1.6.1"
-zerocopy = { version = "0.7.32", optional = true, features = ["derive"] }
+base64 = "0.22.1"
+bytemuck = { version = "1.15.0", optional = true, features = ["derive"] }
+serde = { version = "1.0.200", optional = true }
+uuid = "1.8.0"
+zerocopy = { version = "0.7.33", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 hex = "0.4.3"
-clap = "4.4.11"
+clap = "4.5.4"
 serde_test = "1.0.176"
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,9 @@ use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 use uuid::Uuid;
 
+#[cfg(all(uuid_unstable, feature = "zerocopy"))]
+use zerocopy::{AsBytes, FromBytes, Unaligned};
+
 /// A short, URL-safe UUID representation.
 ///
 /// ## Example
@@ -52,10 +55,10 @@ use uuid::Uuid;
 /// ```
 #[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-// #[cfg_attr(
-//      feature = "zerocopy",
-//      derive(zerocopy::AsBytes, zerocopy::FromBytes, zerocopy::Unaligned)
-// )]
+#[cfg_attr(
+    all(uuid_unstable, feature = "zerocopy"),
+    derive(AsBytes, FromBytes, Unaligned)
+)]
 #[cfg_attr(
     feature = "bytemuck",
     derive(bytemuck::Zeroable, bytemuck::Pod, bytemuck::TransparentWrapper)


### PR DESCRIPTION
Adds support for the `zerocopy` create feature. This is currently flagged unstable by the `uuid` crate itself and appears to fail compilation even with the approriate `RUSTFLAGS`.