### PR TITLE
Add codecov support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,3 +1,4 @@
+---
 name: Rust
 
 on:
@@ -11,14 +12,15 @@ env:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose --features=serde
-    - name: Run doctests
-      run: cargo test --doc --verbose --features=serde
+      - uses: actions/checkout@v4
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose --features=serde
+      - name: Run doctests
+        run: cargo test --doc --verbose --features=serde

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,15 +12,42 @@ env:
 
 jobs:
   build:
+    name: Build and Test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check format
+        run: cargo fmt --check
+      - name: Build
+        run: cargo build --verbose
+      - uses: taiki-e/install-action@nextest
+      - name: Run tests
+        run: cargo nextest run --verbose --all-features
+      - name: Run doctests
+        run: cargo test --doc --verbose --all-features
+
+  codecov:
+    name: Code Coverage
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Build
         run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose --features=serde
-      - name: Run doctests
-        run: cargo test --doc --verbose --features=serde
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - name: Generate code coverage
+        run: cargo llvm-cov nextest --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 /.idea
+/lcov.info

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,11 @@ required-features = ["serde"]
 
 [dependencies]
 arbitrary = { version = "1.3.2", optional = true }
-base64 = "0.21.5"
-bytemuck = { version = "1.14.0", optional = true, features = ["derive"] }
-serde = { version = "1.0.193", optional = true }
-uuid = "1.6.1"
-zerocopy = { version = "0.7.32", optional = true, features = ["derive"] }
+base64 = "0.22.1"
+bytemuck = { version = "1.15.0", optional = true, features = ["derive"] }
+serde = { version = "1.0.200", optional = true }
+uuid = "1.8.0"
+zerocopy = { version = "0.7.33", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # ShortGuid
 
-Short URL-safe Base64 encoded UUIDs. 
+[![codecov](https://codecov.io/gh/nyris/shortguid-rs/graph/badge.svg?token=YOM7OCX28D)](https://codecov.io/gh/nyris/shortguid-rs)
+
+Short URL-safe Base64 encoded UUIDs.
 
 ---
 
-ShortGuids transparently represent UUID types but use only 22 characters 
+ShortGuids transparently represent UUID types but use only 22 characters
 in their string representation, as opposed to 36 characters for a dashed
 UUID or 32 without dashes.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! # shortguid
-//! 
+//!
 //! Provides short, URL-safe UUID representations.
 //!
 //! ```


### PR DESCRIPTION
Branching off #12, adds GitHub Actions support for code coverage and reports to codecov.io at https://app.codecov.io/gh/nyris/shortguid-rs.

Main tests (i.e. non-doctest) are now run using [nextest](https://nexte.st/).